### PR TITLE
Example of Window.size and Window.resizes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 # Window Size
 
 Your application lives in a window. This library helps you figure out how big that window is and when it changes size.
+
+## Init
+When your application starts, sending a command with the `Window.size` task will return with an update message of the initial window size.
+
+```elm
+type alias Model =
+    Window.Size
+
+
+type Msg
+    = Resized Window.Size
+
+
+init =
+    ( Window.Size 0 0
+    , Task.perform Resized Window.size
+    )
+
+
+update msg model =
+    case msg of
+        Resized size ->
+            ( size, Cmd.none )
+
+```
+
+## Subscriptions
+The window can change size when the user's phone is turned sideways, or the user changes the window size on a desktop.
+
+Use the `Window.resizes` subscription to get updates when the window size changes.
+
+```elm
+type Msg
+    = Resized Window.Size
+
+subscriptions model =
+    Window.resizes Resized
+```


### PR DESCRIPTION
Some quick examples of the `Window.size` Task, and `Window.resizes` Sub for the main README docs.

* The **init** example also has the `Model`, `Msg`, `init`, and `update` functions for high copypastability.
* The **subscriptions** example is shorter because you probably need the init if you care about window size on Subs since subscribing doesn't fire an initial message.

Tried to keep them short, and complete.  😅 